### PR TITLE
Allow third party libs to export object vaidators w/ type defs

### DIFF
--- a/src/ok-computer.ts
+++ b/src/ok-computer.ts
@@ -336,6 +336,12 @@ type ObjReturnTypes<T extends Record<keyof T, (...a: any[]) => any>> = {
 
 export const OBJECT_ROOT = Symbol.for('ok-computer.object-root');
 
+export type ObjectErrorStruct<
+  Validators extends Record<any, (...a: any[]) => any>
+> = ObjReturnTypes<Validators> & {
+  [OBJECT_ROOT]?: string;
+} & IStructure;
+
 export const object =
   <
     Validators extends Record<
@@ -345,11 +351,7 @@ export const object =
   >(
     validators: Validators,
     { allowUnknown = false }: { allowUnknown?: boolean } = {}
-  ): StructValidator<
-    ObjReturnTypes<Validators> & {
-      [OBJECT_ROOT]?: string;
-    } & IStructure
-  > =>
+  ): StructValidator<ObjectErrorStruct<Validators>> =>
   (...parents: unknown[]) => {
     const values = parents[0];
     const introspecting = values === INTROSPECT;


### PR DESCRIPTION

Third party lib:

```ts
import { object } from 'ok-computer';

export const validator = object({ name: string });
```

Build with type defs using `tsc -d` errors with:
```
TS4023: Exported variable 'validator' has or is using name 'OBJECT_ROOT' from external module "/third-party-lib/node_modules/ok-computer/dist/ok-computer" but cannot be named.
```

https://github.com/microsoft/TypeScript/issues/5711

