### PR TITLE
Assert type using `assert(validator, value)`

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -182,7 +182,8 @@ export class NegateError<T>
 
 export class AssertError extends Error {
   public errors: ErrItem<any>[];
-  constructor(errors: ErrItem<any>[]) {
+  public value?: unknown;
+  constructor(errors: ErrItem<any>[], value?: unknown) {
     super();
     try {
       const firstError = errors[0];
@@ -197,5 +198,6 @@ export class AssertError extends Error {
       this.message = 'Invalid';
     }
     this.errors = errors;
+    this.value = value;
   }
 }

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -44,13 +44,16 @@ it('works', () => {
     ),
     country: err(oneOf('US', 'GB'), 'Expected either US or GB')
   });
-  const errors1 = validator({
+  const input1 = {
     password: 'erm',
     addresses: [{ line2: false }, null]
-  });
+  };
+  const errors1 = validator(input1);
   expect(isError(errors1)).toBe(true);
   expect(hasError(errors1)).toBe(true);
-  expect(() => assert(errors1)).toThrow(new AssertError(listErrors(errors1)));
+  expect(() => assert(validator, input1)).toThrow(
+    new AssertError(listErrors(errors1))
+  );
   const error = new AssertError(listErrors(errors1));
   expect(error.message).toBe(
     'Invalid: first of 11 errors: username: (Expected typeof string and expected length between 3 and 30)'
@@ -127,7 +130,7 @@ it('works', () => {
         },
       ]
     `);
-  const errors2 = validator({
+  const input2 = {
     username: 'lh44',
     password: 'password123',
     repeat_password: 'password123',
@@ -140,10 +143,11 @@ it('works', () => {
       }
     ],
     country: 'GB'
-  });
+  };
+  const errors2 = validator(input2);
   expect(isError(errors2)).toBe(false);
   expect(hasError(errors2)).toBe(false);
-  expect(() => assert(errors2)).not.toThrow();
+  expect(() => assert(validator, input2)).not.toThrow();
   expect(errors2).toMatchInlineSnapshot(`
       Object {
         "access_token": undefined,

--- a/src/ok-computer.test.ts
+++ b/src/ok-computer.test.ts
@@ -1713,11 +1713,10 @@ describe('andPeer', () => {
     }
   ].forEach((t) => {
     test(t.description, () => {
-      const errors = validator(t.input);
       if (t.valid) {
-        expect(() => assert(errors)).not.toThrow();
+        expect(() => assert(validator, t.input)).not.toThrow();
       } else {
-        expect(() => assert(errors)).toThrow();
+        expect(() => assert(validator, t.input)).toThrow();
       }
     });
   });
@@ -1740,11 +1739,11 @@ describe('andPeer', () => {
   ].forEach(([A, B, C, Q]) => {
     test(`${A} ${B} ${C} ${Q}`, () => {
       const toVal = (v: unknown) => (v ? 'valid value' : undefined);
-      const errors = validator2({ A: toVal(A), B: toVal(B), C: toVal(C) });
+      const input = { A: toVal(A), B: toVal(B), C: toVal(C) };
       if (Q) {
-        expect(() => assert(errors)).not.toThrow();
+        expect(() => assert(validator2, input)).not.toThrow();
       } else {
-        expect(() => assert(errors)).toThrow();
+        expect(() => assert(validator2, input)).toThrow();
       }
     });
   });
@@ -1824,11 +1823,10 @@ describe('nandPeer', () => {
     }
   ].forEach((t) => {
     test(t.description, () => {
-      const errors = validator(t.input);
       if (t.valid) {
-        expect(() => assert(errors)).not.toThrow();
+        expect(() => assert(validator, t.input)).not.toThrow();
       } else {
-        expect(() => assert(errors)).toThrow();
+        expect(() => assert(validator, t.input)).toThrow();
       }
     });
   });
@@ -1852,11 +1850,11 @@ describe('nandPeer', () => {
   ].forEach(([A, B, C, Q]) => {
     test(`${A} ${B} ${C} ${Q}`, () => {
       const toVal = (v: unknown) => (v ? 'valid value' : undefined);
-      const errors = validator2({ A: toVal(A), B: toVal(B), C: toVal(C) });
+      const input = { A: toVal(A), B: toVal(B), C: toVal(C) };
       if (Q) {
-        expect(() => assert(errors)).not.toThrow();
+        expect(() => assert(validator2, input)).not.toThrow();
       } else {
-        expect(() => assert(errors)).toThrow();
+        expect(() => assert(validator2, input)).toThrow();
       }
     });
   });
@@ -1936,11 +1934,10 @@ describe('orPeer', () => {
     }
   ].forEach((t) => {
     test(t.description, () => {
-      const errors = validator(t.input);
       if (t.valid) {
-        expect(() => assert(errors)).not.toThrow();
+        expect(() => assert(validator, t.input)).not.toThrow();
       } else {
-        expect(() => assert(errors)).toThrow();
+        expect(() => assert(validator, t.input)).toThrow();
       }
     });
   });
@@ -1965,11 +1962,10 @@ describe('orPeer', () => {
     test(`${A} ${B} ${C} ${Q}`, () => {
       const toVal = (v: unknown) => (v ? 'valid value' : undefined);
       const input = { A: toVal(A), B: toVal(B), C: toVal(C) };
-      const errors = validator2(input);
       if (Q) {
-        expect(() => assert(errors)).not.toThrow();
+        expect(() => assert(validator2, input)).not.toThrow();
       } else {
-        expect(() => assert(errors)).toThrow();
+        expect(() => assert(validator2, input)).toThrow();
       }
     });
   });
@@ -2049,11 +2045,10 @@ describe('xorPeer', () => {
     }
   ].forEach((t) => {
     test(t.description, () => {
-      const errors = validator(t.input);
       if (t.valid) {
-        expect(() => assert(errors)).not.toThrow();
+        expect(() => assert(validator, t.input)).not.toThrow();
       } else {
-        expect(() => assert(errors)).toThrow();
+        expect(() => assert(validator, t.input)).toThrow();
       }
     });
   });
@@ -2078,11 +2073,10 @@ describe('xorPeer', () => {
     test(`${A} ${B} ${C} ${Q}`, () => {
       const toVal = (v: unknown) => (v ? 'valid value' : undefined);
       const input = { A: toVal(A), B: toVal(B), C: toVal(C) };
-      const errors = validator2(input);
       if (Q) {
-        expect(() => assert(errors)).not.toThrow();
+        expect(() => assert(validator2, input)).not.toThrow();
       } else {
-        expect(() => assert(errors)).toThrow();
+        expect(() => assert(validator2, input)).toThrow();
       }
     });
   });
@@ -2165,9 +2159,9 @@ describe('oxorPeer', () => {
     test(t.description, () => {
       const errors = validator(t.input);
       if (t.valid) {
-        expect(() => assert(errors)).not.toThrow();
+        expect(() => assert(validator, t.input)).not.toThrow();
       } else {
-        expect(() => assert(errors)).toThrow();
+        expect(() => assert(validator, t.input)).toThrow();
       }
     });
   });
@@ -2191,11 +2185,10 @@ describe('oxorPeer', () => {
     test(`${A} ${B} ${C} ${Q}`, () => {
       const toVal = (v: unknown) => (v ? 'valid value' : undefined);
       const input = { A: toVal(A), B: toVal(B), C: toVal(C) };
-      const errors = validator2(input);
       if (Q) {
-        expect(() => assert(errors)).not.toThrow();
+        expect(() => assert(validator2, input)).not.toThrow();
       } else {
-        expect(() => assert(errors)).toThrow();
+        expect(() => assert(validator2, input)).toThrow();
       }
     });
   });

--- a/src/ok-computer.ts
+++ b/src/ok-computer.ts
@@ -93,15 +93,16 @@ export const isError = <Err>(err: Err): err is Exclude<Err, undefined> =>
   !!listErrors(err).length;
 export const hasError = isError;
 
-// TODO: assert type guard. Signature would have to change to
-// `assert(validator, values)`
-// Which does open the door to optionally logging the values too (desirable in some cases)
-export const assert = <Err>(err: Err) => {
-  const errors = listErrors(err);
+export function assert<V extends Validator>(
+  validator: V,
+  value: unknown,
+  logValue: boolean = false
+): asserts value is Infer<V> {
+  const errors = listErrors(validator(value));
   if (errors.length) {
-    throw new AssertError(errors);
+    throw new AssertError(errors, logValue ? value : undefined);
   }
-};
+}
 
 export const withErr =
   <Err, V extends Validator<any, any>>(


### PR DESCRIPTION
```ts
import { object, string, assert } from 'ok-computer';
const validator = object({ name: string });
const value: unknown = 'foo';
type A = typeof value; // unknown
assert(validator, value); // throw new AssertError(errors);
type B = typeof value; // { name: string; }
assert(validator, value, true); // throw new AssertError(errors, value);
```

TODO:
- [ ] Update docs