### PR TITLE
Add `exists`

### DIFF
--- a/src/ok-computer.test.ts
+++ b/src/ok-computer.test.ts
@@ -46,7 +46,8 @@ import {
   orPeers,
   oxorPeers,
   xorPeers,
-  okay
+  okay,
+  exists
 } from './ok-computer';
 import {
   ANDError,
@@ -2213,5 +2214,33 @@ describe('okay', () => {
     if (okay(validator, value)) {
       value[0].toExponential(); // no ts-error
     }
+  });
+});
+
+describe('exists', () => {
+  test('valid', () => {
+    expect(exists('')).toBe(undefined);
+    expect(exists(' ')).toBe(undefined);
+    expect(exists('foo')).toBe(undefined);
+    expect(exists(true)).toBe(undefined);
+    expect(exists(false)).toBe(undefined);
+    expect(exists(-1)).toBe(undefined);
+    expect(exists(0)).toBe(undefined);
+    expect(exists(1)).toBe(undefined);
+    expect(exists(NaN)).toBe(undefined);
+    expect(exists(Infinity)).toBe(undefined);
+    expect(exists(-Infinity)).toBe(undefined);
+    expect(exists({})).toBe(undefined);
+    expect(exists({ foo: 'bar' })).toBe(undefined);
+    expect(exists([])).toBe(undefined);
+    expect(exists(new Date('2021-01-09'))).toBe(undefined);
+  });
+
+  test('invalid', () => {
+    expect(exists(undefined)).toEqual(new NegateError('Expected nullish'));
+    expect(exists(null)).toEqual(new NegateError('Expected nullish'));
+    expect(JSON.stringify(exists(undefined))).toBe(
+      '"not(\\"Expected nullish\\")"'
+    );
   });
 });


### PR DESCRIPTION
In cases where you don't have a dedicated validator for a type, you'll often use `assert` from node.js or something similar such as [`tiny-invariant`](https://github.com/alexreardon/tiny-invariant) to check something exists or not, e.g.

```ts
import assert from 'assert'; // node.js

interface Foo { name: string; }

const fn = (foo?: Foo) => {
  assert(!!foo, 'Expected foo');
  return foo.name.trim(); // foo is `string` here
}
```

node.js `assert` defines the asserts type using `asserts condition` https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html

This PR supports the same use case using `asserts value is T` by exposing an `exists` validator which asserts the value exists (`Validator<{}, any>`) e.g.

```ts
import { assert, exists } from 'ok-computer';

interface Foo { name: string; }

const fn = (foo?: Foo) => {
  assert(exists, foo);
  return foo.name.trim(); // foo is `string` here
}
```

> NOTE: At runtime, it's merely an alias for `not(nullish)`.

